### PR TITLE
Remove QSL as a dependency on quilt

### DIFF
--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -31,10 +31,6 @@
 			{
 				"id": "quilt_loader",
 				"versions": ">=0.16.0-"
-			},
-			{
-				"id": "quilted_fabric_api",
-				"versions": ">=2.0.0-"
 			}
 		]
 	},


### PR DESCRIPTION
removing it as FAPI isn't a dependency on the fabric version and the mod seems to work perfectly fine on quilt without QSL installed
![image](https://user-images.githubusercontent.com/54289108/187092401-abb3b3ad-37ba-4818-97a9-5dca0e2e9124.png)
